### PR TITLE
feat: allow multiple runs SPDV-216

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,10 @@
-import { Bee } from '@ethersphere/bee-js';
 import fs from 'fs';
 
 import 'dotenv/config';
 
-import { MediaWatcher } from './libs/MediaWatcher';
-import { startRtmpServer, waitForStreamPath } from './libs/RTMPServer';
-import { SwarmStreamUploader } from './libs/SwarmStreamUploader';
-import { getEnvVariable } from './utils/common';
-
+import { startRtmpServer } from './libs/RTMPServer';
 const mediaRootPath = process.argv[2] || './media'; // Get from CLI or use default
 const ffmpegPath = process.argv[3];
-
-const WRITER_BEE_URL = getEnvVariable('WRITER_BEE_URL');
-const MANIFEST_SEGMENT_URL = getEnvVariable('MANIFEST_SEGMENT_URL');
-const STREAM_STAMP = getEnvVariable('STREAM_STAMP');
-const GSOC_KEY = getEnvVariable('GSOC_KEY');
-const GSOC_TOPIC = getEnvVariable('GSOC_TOPIC');
 
 async function startServer() {
   // Clean up previous run
@@ -24,15 +13,6 @@ async function startServer() {
   }
 
   startRtmpServer(mediaRootPath, ffmpegPath);
-
-  const streamPath = await waitForStreamPath();
-
-  // pass bee here to reduce testing complexity
-  const bee = new Bee(WRITER_BEE_URL);
-  const uploader = new SwarmStreamUploader(bee, MANIFEST_SEGMENT_URL, GSOC_KEY, GSOC_TOPIC, STREAM_STAMP, streamPath);
-  const watcher = new MediaWatcher(streamPath, uploader.enqueueNewSegment.bind(uploader));
-
-  watcher.start();
 }
 
 startServer();

--- a/src/libs/DirectoryHandler.test.ts
+++ b/src/libs/DirectoryHandler.test.ts
@@ -1,0 +1,60 @@
+import { DirectoryHandler } from './DirectoryHandler';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(() => 'abc'),
+  rmSync: jest.fn(),
+}));
+
+jest.mock('./Logger', () => ({
+  Logger: { getInstance: () => ({ log: jest.fn(), error: jest.fn(), info: jest.fn() }) },
+}));
+
+jest.mock('./ErrorHandler', () => ({
+  ErrorHandler: { getInstance: () => ({ handleError: jest.fn() }) },
+}));
+
+const mockedBeeInstance = {
+  uploadData: jest.fn().mockResolvedValue({ reference: { toHex: () => 'mockRef' } }),
+  gsocSend: jest.fn().mockResolvedValue({ reference: { toHex: () => 'gsocRef' } }),
+};
+
+jest.mock('@ethersphere/bee-js', () => ({
+  Bee: jest.fn(() => mockedBeeInstance),
+  PrivateKey: jest.fn().mockImplementation(() => ({
+    sign: jest.fn().mockResolvedValue('mocked-signature'),
+  })),
+  Identifier: { fromString: jest.fn(() => null) },
+}));
+
+jest.mock('../utils/common', () => ({
+  getEnvVariable: jest.fn(
+    (key: string) =>
+      ({
+        WRITER_BEE_URL: 'http://mocked-url',
+        MANIFEST_SEGMENT_URL: 'http://mocked-manifest-url',
+        STREAM_STAMP: 'mocked-stream-stamp',
+        GSOC_KEY: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        GSOC_TOPIC: 'mocked-gsoc-topic',
+      }[key]),
+  ),
+  retryAwaitableAsync: jest.requireActual('../utils/common').retryAwaitableAsync,
+}));
+
+jest.mock('./MediaWatcher', () => ({
+  MediaWatcher: jest.fn().mockImplementation((path, onAdd) => ({
+    // At this point (in the start), the `onAdd` callback is triggered with the mock file path `/mock/path/file.ts`
+    start: jest.fn(() => onAdd('/mock/path/file.ts')),
+  })),
+}));
+
+describe('DirectoryHandler', () => {
+  it('should call gsocSend and uploadData on the mocked Bee instance', async () => {
+    const directoryHandler = DirectoryHandler.getInstance();
+    directoryHandler.handleDir('/mock/path');
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    expect(mockedBeeInstance.gsocSend).toHaveBeenCalled();
+    expect(mockedBeeInstance.uploadData).toHaveBeenCalled();
+  });
+});

--- a/src/libs/DirectoryHandler.ts
+++ b/src/libs/DirectoryHandler.ts
@@ -1,0 +1,52 @@
+import { Bee } from '@ethersphere/bee-js';
+
+import { getEnvVariable } from '../utils/common';
+
+import { Logger } from './Logger';
+import { MediaWatcher } from './MediaWatcher'; // Import MediaWatcher
+import { Queue } from './Queue';
+import { SwarmStreamUploader } from './SwarmStreamUploader'; // Import SwarmStreamUploader
+
+const WRITER_BEE_URL = getEnvVariable('WRITER_BEE_URL');
+const MANIFEST_SEGMENT_URL = getEnvVariable('MANIFEST_SEGMENT_URL');
+const STREAM_STAMP = getEnvVariable('STREAM_STAMP');
+const GSOC_KEY = getEnvVariable('GSOC_KEY');
+const GSOC_TOPIC = getEnvVariable('GSOC_TOPIC');
+
+export class DirectoryHandler {
+  private logger = Logger.getInstance();
+  private queue: Queue;
+
+  private static instance: DirectoryHandler;
+  private static handledDirs = new Set<string>();
+
+  private constructor() {
+    this.queue = new Queue();
+  }
+
+  public static getInstance(): DirectoryHandler {
+    if (!DirectoryHandler.instance) {
+      DirectoryHandler.instance = new DirectoryHandler();
+    }
+    return DirectoryHandler.instance;
+  }
+
+  public handleDir(path: string): void {
+    if (DirectoryHandler.handledDirs.has(path)) {
+      this.logger.info(`Already handling directory: ${path}`);
+      return;
+    }
+    DirectoryHandler.handledDirs.add(path);
+    this.logger.info(`Handling directory: ${path}`);
+    this.queue.enqueue(async () => {
+      try {
+        const bee = new Bee(WRITER_BEE_URL);
+        const uploader = new SwarmStreamUploader(bee, MANIFEST_SEGMENT_URL, GSOC_KEY, GSOC_TOPIC, STREAM_STAMP, path);
+        const watcher = new MediaWatcher(path, uploader.enqueueNewSegment.bind(uploader));
+        watcher.start();
+      } catch (error) {
+        this.logger.error(`Error handling directory ${path}:`, error);
+      }
+    });
+  }
+}


### PR DESCRIPTION
# 🔖 Title

Allow multiple runs

---

## 📝 Description

Once the server is up, you can start the same path stream multiple times, and it can also handle several different streams in parallel.

---

## 🔗 Related Issues

- https://solar-punk.atlassian.net/browse/SPDV-216

---

## ✨ Changes Made

- Added `/src/libs/DirectoryHandler`
- Refactored `src/libs/RTMPServer`
- Refactored `src/index.ts`

---

## 🧪 How Has This Been Tested?

- [x] Manually tested - After manually starting the server: multiple different streams can be started in parallel
- [x] Added unit tests with Jest
- [x] Ran `npm run test` and `tsc --noEmit`

---

## ✅ Checklist

- [x] My code follows the project’s style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
