### PR TITLE
Chore: Refactor SwarmStreamUploader.ts SPDV-234

### DIFF
--- a/src/libs/HlsManifestManager.test.ts
+++ b/src/libs/HlsManifestManager.test.ts
@@ -1,0 +1,105 @@
+// src/libs/HlsManifestManager.test.ts
+import fs from 'fs';
+
+import { HlsManifestManager, HlsManifestOptions } from './HlsManifestManager';
+
+jest.mock('fs');
+
+describe('HlsManifestManager', () => {
+  const originalPath = '/mock/original.m3u8';
+  const swarmPath = '/mock/playlist.m3u8';
+  const beeUrl = 'http://swarm/bytes';
+  const baseOptions: HlsManifestOptions = {
+    originalManifestPath: originalPath,
+    swarmManifestPath: swarmPath,
+    manifestBeeUrl: beeUrl,
+    targetDuration: 5,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loadOriginalManifest parses EXTINF, MEDIA-SEQUENCE, TARGETDURATION', () => {
+    const sample = [
+      '#EXTM3U',
+      '#EXT-X-VERSION:3',
+      '#EXT-X-TARGETDURATION:7',
+      '#EXT-X-MEDIA-SEQUENCE:42',
+      '#EXTINF:3.5,',
+      'seg1.ts',
+      '#EXTINF:4.0,',
+      'seg2.ts',
+    ].join('\n');
+
+    (fs.readFileSync as jest.Mock).mockReturnValue(sample);
+
+    const mgr = new HlsManifestManager(baseOptions);
+    mgr.loadOriginalManifest();
+
+    // Internally, segments should be two entries with correct durations & URIs
+    const content = mgr.getManifestContent();
+    expect(content).toContain('#EXT-X-TARGETDURATION:7');
+    expect(content).toContain('#EXT-X-MEDIA-SEQUENCE:42');
+    expect(content).toContain('#EXTINF:3.500000,');
+    expect(content).toContain('seg1.ts');
+    expect(content).toContain('#EXTINF:4.000000,');
+    expect(content).toContain('seg2.ts');
+  });
+
+  it('getSegmentDurationFromOriginal returns correct duration or default', () => {
+    const sample = ['#EXTINF:2.2,', 'foo.ts', '#EXTINF:3.3,', 'bar.ts'].join('\n');
+    (fs.readFileSync as jest.Mock).mockReturnValue(sample);
+
+    const mgr = new HlsManifestManager(baseOptions);
+
+    const durFoo = mgr.getSegmentDurationFromOriginal('/some/path/foo.ts');
+    expect(durFoo).toBeCloseTo(2.2);
+
+    const durMissing = mgr.getSegmentDurationFromOriginal('/some/path/unknown.ts');
+    expect(durMissing).toBe(baseOptions.targetDuration!);
+  });
+
+  it('addSegment and getManifestContent include new Swarm URIs', () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue(''); // no original
+    const mgr = new HlsManifestManager(baseOptions);
+
+    mgr.addSegment('abc123', 5.5);
+    const content = mgr.getManifestContent();
+
+    expect(content).toContain('#EXTINF:5.500000,');
+    expect(content).toContain(`${beeUrl}/abc123`);
+  });
+
+  it('closePlaylist appends EXT-X-ENDLIST', () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue('');
+    const mgr = new HlsManifestManager(baseOptions);
+
+    mgr.addSegment('ref1', 1.1);
+    mgr.closePlaylist();
+    const content = mgr.getManifestContent();
+
+    expect(content.trim().endsWith('#EXT-X-ENDLIST')).toBe(true);
+  });
+
+  it('saveManifest writes out the manifest file', () => {
+    const mgr = new HlsManifestManager(baseOptions);
+    // stub getManifestContent
+    jest.spyOn(mgr, 'getManifestContent').mockReturnValue('PLAYLIST');
+    mgr.saveManifest();
+    expect(fs.writeFileSync).toHaveBeenCalledWith(swarmPath, 'PLAYLIST');
+  });
+
+  it('getTotalDuration sums segment durations', () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue('');
+    const mgr = new HlsManifestManager(baseOptions);
+
+    // manually push segments
+    (mgr as any).segments = [
+      { duration: 2.0, uri: 'a' },
+      { duration: 3.5, uri: 'b' },
+    ];
+
+    expect(mgr.getTotalDuration()).toBeCloseTo(5.5);
+  });
+});

--- a/src/libs/HlsManifestManager.ts
+++ b/src/libs/HlsManifestManager.ts
@@ -1,0 +1,126 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface HlsManifestOptions {
+  originalManifestPath: string;
+  swarmManifestPath: string;
+  manifestBeeUrl: string;
+  targetDuration?: number;
+}
+
+interface Segment {
+  duration: number;
+  uri: string;
+}
+
+export class HlsManifestManager {
+  private originalManifestPath: string;
+  private swarmManifestPath: string;
+  private manifestBeeUrl: string;
+  private targetDuration: number;
+  private mediaSequence: number;
+  private segments: Segment[] = [];
+  private closed: boolean = false;
+
+  constructor(options: HlsManifestOptions) {
+    this.originalManifestPath = options.originalManifestPath;
+    this.swarmManifestPath = options.swarmManifestPath;
+    this.manifestBeeUrl = options.manifestBeeUrl;
+    this.targetDuration = options.targetDuration ?? 6;
+    this.mediaSequence = 0;
+  }
+
+  /**
+   * Load and parse the original manifest file produced by FFmpeg
+   */
+  public loadOriginalManifest(): void {
+    const content = fs.readFileSync(this.originalManifestPath, 'utf-8');
+    const lines = content.split(/\r?\n/);
+    this.segments = [];
+    this.mediaSequence = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line.startsWith('#EXTINF:')) {
+        const match = line.match(/^#EXTINF:([\d.]+),?/);
+        if (match) {
+          const duration = parseFloat(match[1]);
+          const uriLine = lines[i + 1]?.trim() || '';
+          this.segments.push({ duration, uri: uriLine });
+        }
+      } else if (line.startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+        const seq = parseInt(line.split(':')[1], 10);
+        if (!isNaN(seq)) this.mediaSequence = seq;
+      } else if (line.startsWith('#EXT-X-TARGETDURATION:')) {
+        const td = parseInt(line.split(':')[1], 10);
+        if (!isNaN(td)) this.targetDuration = td;
+      }
+    }
+  }
+
+  /**
+   * Retrieve the duration for a specific segment from the original manifest
+   */
+  public getSegmentDurationFromOriginal(segmentPath: string): number {
+    const name = path.basename(segmentPath);
+    const content = fs.readFileSync(this.originalManifestPath, 'utf-8');
+    const lines = content.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim() === name && i > 0) {
+        const prev = lines[i - 1].trim();
+        const match = prev.match(/^#EXTINF:([\d.]+),?/);
+        if (match) return parseFloat(match[1]);
+      }
+    }
+    return this.targetDuration;
+  }
+
+  /**
+   * Add a new segment entry to the playlist (with Swarm URI)
+   */
+  public addSegment(swarmRef: string, duration: number): void {
+    const uri = `${this.manifestBeeUrl}/${swarmRef}`;
+    this.segments.push({ duration, uri });
+  }
+
+  /**
+   * Mark playlist as ended (for VOD)
+   */
+  public closePlaylist(): void {
+    this.closed = true;
+  }
+
+  /**
+   * Generate HLS manifest content
+   */
+  public getManifestContent(): string {
+    const header = [
+      '#EXTM3U',
+      '#EXT-X-VERSION:3',
+      `#EXT-X-TARGETDURATION:${this.targetDuration}`,
+      `#EXT-X-MEDIA-SEQUENCE:${this.mediaSequence}`,
+    ];
+
+    const body = this.segments.flatMap(seg => [`#EXTINF:${seg.duration.toFixed(6)},`, seg.uri]);
+
+    if (this.closed) {
+      body.push('#EXT-X-ENDLIST');
+    }
+
+    return header.concat(body).join('\n') + '\n';
+  }
+
+  /**
+   * Persist the updated manifest to disk
+   */
+  public saveManifest(): void {
+    fs.writeFileSync(this.swarmManifestPath, this.getManifestContent());
+  }
+
+  /**
+   * Compute total duration of all segments in the playlist
+   */
+  public getTotalDuration(): number {
+    return this.segments.reduce((sum, seg) => sum + seg.duration, 0);
+  }
+}


### PR DESCRIPTION
# 🔖 Title

Refactor SwarmStreamUploader to extract HLS manifest logic into HlsManifestManager

---

## 📝 Description

This PR separates out all of the HLS playlist parsing, building, and file I/O from the SwarmStreamUploader class into a dedicated HlsManifestManager. The uploader now focuses solely on reading segments, enqueueing Swarm/Bee uploads, and signaling GSOC feed events, while the new manager handles:

- Loading and parsing the original index.m3u8
- Extracting #EXTINF: durations
- Building and saving the new playlist.m3u8
- Appending #EXT-X-ENDLIST
- Computing total duration for VOD_

---

## 🔗 Related Issues

[https://solar-punk.atlassian.net/browse/SPDV-234](https://solar-punk.atlassian.net/browse/SPDV-234)

---

## ✨ Changes Made

1. Created src/libs/HlsManifestManager.ts

- loadOriginalManifest()
- getSegmentDurationFromOriginal()
- addSegment()
- closePlaylist()
- getManifestContent()
- saveManifest()
- getTotalDuration()

2. Updated src/libs/SwarmStreamUploader.ts

- Removed all inline manifest parsing/building methods (buildManifest, upsertManifest, etc.)
- Inject and delegate to HlsManifestManager for playlist updates
- Simplified broadcastStart() / broadcastStop() to call saveManifest() instead of custom logic
- Preserved segment‐upload orchestration and GSOC feed notifications

---

## 🧪 How Has This Been Tested?

- Started the RTMP ingestion server
- Streamed live video via FFmpeg (HLS segments)
- Verified segments and updated playlist.m3u8 upload to Swarm
- Confirmed GSOC “live” and “VOD” messages arrive correctly

- [x] Manually tested
- [x] Added unit tests with Jest
- [x] Ran `npm run test` and `tsc --noEmit`

---

## ✅ Checklist

_Ensure you’ve covered all necessary steps before requesting review:_

- [x] My code follows the project’s style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
