### PR TITLE
fix: handle VOD and live(sliding) separately

### DIFF
--- a/src/libs/RTMPServer.test.ts
+++ b/src/libs/RTMPServer.test.ts
@@ -106,12 +106,17 @@ describe('startRtmpServer', () => {
       trans: {
         ffmpeg: '/path/to/ffmpeg',
         tasks: [
-          { app: 'video', hls: true, hlsKeep: true, hlsFlags: '[hls_time=5:hls_list_size=20]' },
+          {
+            app: 'video',
+            hls: true,
+            hlsKeep: true,
+            hlsFlags: '[hls_time=5:hls_list_size=10:hls_flags=delete_segments]',
+          },
           {
             app: 'audio',
             hls: true,
             hlsKeep: true,
-            hlsFlags: '[hls_time=5:hls_list_size=20]',
+            hlsFlags: '[hls_time=5:hls_list_size=10:hls_flags=delete_segments]',
             ac: 'aac',
             ab: '128k',
             mp4: false,

--- a/src/libs/RTMPServer.ts
+++ b/src/libs/RTMPServer.ts
@@ -83,12 +83,12 @@ export function startRtmpServer(mRootPath: string, providedFFmpegPath: string): 
     trans: {
       ffmpeg: ffmpegPath,
       tasks: [
-        { app: 'video', hls: true, hlsKeep: true, hlsFlags: '[hls_time=5:hls_list_size=20]' },
+        { app: 'video', hls: true, hlsKeep: true, hlsFlags: '[hls_time=5:hls_list_size=10:hls_flags=delete_segments]' },
         {
           app: 'audio',
           hls: true,
           hlsKeep: true,
-          hlsFlags: '[hls_time=5:hls_list_size=20]',
+          hlsFlags: '[hls_time=5:hls_list_size=10:hls_flags=delete_segments]',
           ac: 'aac',
           ab: '128k',
           mp4: false,


### PR DESCRIPTION
# 🔖 Title

Manifest management rework.

## 📝 Description

A PR about reworking the way how we handle and build manifests with minor refactors and bigger fixes.

## 🔗 Related Issues

https://solar-punk.atlassian.net/browse/SPDV-235?atlOrigin=eyJpIjoiYWQxZDI2YzZkYzE1NDNlYmJjYTM0ODc0NDhjYWVhZDEiLCJwIjoiaiJ9

## ✨ Changes Made

- Now two types of manifest are made. VOD and LIVE. During the stream OBS creates the original playlist manifest and the segments on the fly. It's a sliding stream which means the manifest for live does not contain all of the segments just a sliding 10 segments buffer.

- VOD manifest is a manifest which consist all of the entries, when the stream stops we update this VOD manifest for the final index so we can have the full stream as a VOD hls segmented stream.

- Because the original manifest processes segments faster we create a temporary live manifest for the live hls segmented stream, this uses the VOD manifest as a reference as the original progresses faster.

- Fixes: sliding segment buffer, correct manifest handling, auto segment remover, correct mediaSequence utilaztion.


## 🧪 How Has This Been Tested?

- unix tests
- full e2e test OBS->ingestion->aggregator->client - both live and VOD with audio and video


## ✅ Checklist

_Ensure you’ve covered all necessary steps before requesting review:_

- [x] My code follows the project’s style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
