### PR TITLE
fix: handle last segment in manifests correctly SPDV-297

### DIFF
--- a/src/libs/SwarmStreamUploader.test.ts
+++ b/src/libs/SwarmStreamUploader.test.ts
@@ -226,6 +226,20 @@ describe('SwarmStreamUploader', () => {
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
 
+  it('onSegmentUpdate should call build manifest', async () => {
+    const uploader = createUploader('audio/mpeg');
+    const mockBuildManifests = vi.spyOn(uploader['manifestManager'], 'buildManifests');
+    vi.spyOn(uploader as any, 'getSegmentData').mockReturnValue({ segmentData: 'mockData', ref: 'mockRef' });
+    vi.spyOn(uploader['manifestManager'] as any, 'getSegmentEntry').mockResolvedValue('#EXTINF:3.3,\nseg.ts');
+    vi.spyOn(uploader['manifestManager'] as any, 'buildVODManifest').mockImplementation(() => {});
+    vi.spyOn(uploader['manifestManager'] as any, 'buildLiveManifest').mockImplementation(() => {});
+
+    uploader.onSegmentUpdate('index2.ts');
+    await uploader['segmentQueue'].onIdle();
+
+    expect(mockBuildManifests).toHaveBeenCalled();
+  });
+
   it('onManifestUpdate should do nothing if path does not match original manifest', () => {
     const uploader = createUploader('video');
     const mockSetOriginalManifest = vi.spyOn(uploader['manifestManager'], 'setOriginalManifest');

--- a/src/libs/SwarmStreamUploader.ts
+++ b/src/libs/SwarmStreamUploader.ts
@@ -113,13 +113,13 @@ export class SwarmStreamUploader {
     this.uploadSegment(segmentPath, data.segmentData);
   }
 
-  public async onManifestUpdate(manifestPath: string) {
-    const fileName = path.basename(manifestPath);
-    if (fileName === this.manifestManager.getOrigiManifestName()) {
-      this.manifestManager.setOriginalManifest();
-      await this.manifestManager.buildManifests();
-      this.uploadManifest(this.manifestManager.getLiveManifestName());
-    }
+  public async onManifestUpdate(_manifestPath: string) {
+    //const fileName = path.basename(manifestPath);
+    //if (fileName === this.manifestManager.getOrigiManifestName()) {
+    //  this.manifestManager.setOriginalManifest();
+    //  await this.manifestManager.buildManifests();
+    //  this.uploadManifest(this.manifestManager.getLiveManifestName());
+    //}
   }
 
   private uploadSegment(segmentPath: string, segmentData: Uint8Array) {
@@ -129,6 +129,12 @@ export class SwarmStreamUploader {
         this.manifestManager.addToSegmentBuffer(segmentPath, result.reference.toHex());
         fs.rmSync(segmentPath, { force: true });
         this.isFirstSegmentReady = true;
+        // After uploading each segment, we need to update the manifests
+        // to ensure the last segment is not cut off!
+        // See JIRA: https://solar-punk.atlassian.net/browse/SPDV-297
+        this.manifestManager.setOriginalManifest();
+        await this.manifestManager.buildManifests();
+        this.uploadManifest(this.manifestManager.getLiveManifestName());
 
         this.logger.log(`Segment upload result: ${segmentPath}`, result.reference.toHex());
       } else {


### PR DESCRIPTION
# 🔖 Title
Fix missing last segment missing in playlists.

---

## 📝 Description

This pull request fixes a bug where the last segment was missing from the generated `.m3u8` manifest files.

---

## 🔗 Related Issues

https://solar-punk.atlassian.net/browse/SPDV-297

---

## ✨ Changes Made

* Moved `buildManifest` call to run in `onSegmentUpdate`
* Verified that playlist output is correct after the fix

---

## 🧪 How Has This Been Tested?

* ✅ Manually tested with a mocked Bee client (1s delay per method), and `.m3u8` files preserved.
* ✅ Verified playlist files before and after the fix

---

## ✅ Checklist

* ✅ My code follows the project’s style guide
* ✅ I have performed a self-review of my code
* ✅ I have commented my code where necessary
* ✅ I have made corresponding changes to the documentation
* ✅ I have added tests that prove my fix/feature works
* ✅ All new and existing tests pass locally

---
