### PR TITLE
Fix/segment cuts 297 312

### DIFF
--- a/src/libs/DirectoryHandler.test.ts
+++ b/src/libs/DirectoryHandler.test.ts
@@ -70,6 +70,7 @@ vi.mock('./SwarmStreamUploader', () => ({
       onManifestUpdate: vi.fn(),
       broadcastStart: vi.fn().mockResolvedValue(undefined),
       broadcastStop: vi.fn().mockResolvedValue(undefined),
+      waitForStreamDrain: vi.fn().mockResolvedValue(undefined),
     };
   }),
 }));

--- a/src/libs/ManifestManager.ts
+++ b/src/libs/ManifestManager.ts
@@ -214,7 +214,11 @@ export class ManifestManager {
     return entries.slice(mediaSequence);
   }
 
-  public async waitForStreamDrain(dirPath: string, updateManifest: () => Promise<void>): Promise<boolean> {
+  public async waitForStreamDrain(
+    dirPath: string,
+    updateManifest: () => Promise<void>,
+    timeout: number = 5 * 60 * 1000,
+  ): Promise<boolean> {
     let lastIndex = this.getMaxSegmentIndex(dirPath);
     let lastBufferSize = this.segmentBuffer.length;
 
@@ -223,7 +227,6 @@ export class ManifestManager {
     }
 
     const start = Date.now();
-    const timeout = 5 * 60 * 1000; // 5 minutes
 
     this.logger.log(`Waiting for stream drain: .ts max index=${lastIndex}, buffer size=${lastBufferSize}`);
 

--- a/src/libs/ManifestManager.ts
+++ b/src/libs/ManifestManager.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import { sleep } from '../utils/common.js';
+
 import { Logger } from './Logger.js';
 
 interface SegmentBufferEntry {
@@ -210,6 +212,75 @@ export class ManifestManager {
     }
 
     return entries.slice(mediaSequence);
+  }
+
+  public async waitForStreamDrain(dirPath: string, updateManifest: () => Promise<void>): Promise<boolean> {
+    let lastIndex = this.getMaxSegmentIndex(dirPath);
+    let lastBufferSize = this.segmentBuffer.length;
+
+    if (lastIndex === -1 && lastBufferSize === 0) {
+      return true;
+    }
+
+    const start = Date.now();
+    const timeout = 5 * 60 * 1000; // 5 minutes
+
+    this.logger.log(`Waiting for stream drain: .ts max index=${lastIndex}, buffer size=${lastBufferSize}`);
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await sleep(2000);
+
+      const currentIndex = this.getMaxSegmentIndex(dirPath);
+      const currentBufferSize = this.segmentBuffer.length;
+
+      // Check for drain completion
+      if (currentIndex === -1 && currentBufferSize === 0) {
+        this.logger.log(`Stream drain complete: all .ts segments removed and buffer empty.`);
+        return true;
+      }
+
+      // If buffer not empty, call updateManifest
+      if (currentBufferSize > 0) {
+        this.logger.debug(`Buffer not empty (size: ${currentBufferSize}), updating manifest...`);
+        await updateManifest();
+      }
+
+      // Timeout if nothing is progressing
+      if (currentIndex >= lastIndex && currentBufferSize >= lastBufferSize && Date.now() - start > timeout) {
+        this.logger.warn(
+          `Drain stuck at .ts index ${currentIndex}, buffer size ${currentBufferSize} for over 5 minutes, aborting wait.`,
+        );
+        return false;
+      }
+
+      if (currentIndex >= lastIndex && currentIndex !== -1) {
+        this.logger.debug(`Still waiting… .ts segment index not decreasing (still at ${currentIndex})`);
+      }
+
+      if (currentBufferSize >= lastBufferSize && currentBufferSize !== 0) {
+        this.logger.debug(`Still waiting… buffer size not decreasing (still at ${currentBufferSize})`);
+      }
+
+      lastIndex = currentIndex;
+      lastBufferSize = currentBufferSize;
+    }
+  }
+
+  private getMaxSegmentIndex(dir: string): number {
+    let max = -1;
+    const files = fs.readdirSync(dir);
+
+    for (const file of files) {
+      const match = file.match(/^index(\d+)\.ts$/);
+      if (match) {
+        const index = parseInt(match[1], 10);
+        if (index > max) {
+          max = index;
+        }
+      }
+    }
+    return max;
   }
 
   private getOrigiManifestPath(): string {

--- a/src/libs/MediaWatcher.ts
+++ b/src/libs/MediaWatcher.ts
@@ -43,7 +43,6 @@ export class MediaWatcher {
         .on('add', path => {
           this.queue.add(async () => {
             if (path.endsWith('.m3u8') || path.endsWith('.tmp')) {
-              this.logger.warn(`HLS file detected on add: ${path}`);
               return;
             }
 
@@ -57,8 +56,7 @@ export class MediaWatcher {
         })
         .on('change', path => {
           this.queue.add(async () => {
-            if (path.endsWith('.ts') || path.endsWith('.tmp')) {
-              this.logger.warn(`Segment file detected on change: ${path}`);
+            if (path.endsWith('.ts') || path.endsWith('.tmp') || path.includes('playlist')) {
               return;
             }
 

--- a/src/libs/SwarmStreamUploader.test.ts
+++ b/src/libs/SwarmStreamUploader.test.ts
@@ -232,7 +232,7 @@ describe('SwarmStreamUploader', () => {
     const mockBuildManifests = vi.spyOn(uploader['manifestManager'], 'buildManifests');
     const mockUploadManifest = vi.spyOn(uploader as any, 'uploadManifest');
 
-    uploader.onManifestUpdate('/some/other/path.m3u8');
+    uploader.onManifestUpdate();
 
     expect(mockSetOriginalManifest).not.toHaveBeenCalled();
     expect(mockBuildManifests).not.toHaveBeenCalled();

--- a/src/libs/SwarmStreamUploader.test.ts
+++ b/src/libs/SwarmStreamUploader.test.ts
@@ -209,34 +209,13 @@ describe('SwarmStreamUploader', () => {
 
   it('onSegmentUpdate should skip processing manifest files', () => {
     const uploader = createUploader('audio/mpeg');
-    const uploadSpy = vi.spyOn(uploader as any, 'uploadSegment');
+    const uploadManifestSpy = vi.spyOn(uploader as any, 'uploadManifest');
 
-    const manifestPaths = [
-      'index.m3u8',
-      path.join(streamPath, 'playlist-live.m3u8'),
-      path.join(streamPath, 'variant.m3u8'),
-    ];
+    const segmentPath = path.join(streamPath, 'segment.ts');
 
-    manifestPaths.forEach(manifestPath => {
-      uploader.onSegmentUpdate(manifestPath);
-      expect(uploadSpy).not.toHaveBeenCalled();
-      expect(mockBee.uploadData).not.toHaveBeenCalled();
-    });
-
+    uploader.onSegmentUpdate(segmentPath);
+    expect(uploadManifestSpy).not.toHaveBeenCalled();
     expect(fs.writeFileSync).not.toHaveBeenCalled();
-  });
-
-  it('onManifestUpdate should do nothing if path does not match original manifest', () => {
-    const uploader = createUploader('video');
-    const mockSetOriginalManifest = vi.spyOn(uploader['manifestManager'], 'setOriginalManifest');
-    const mockBuildManifests = vi.spyOn(uploader['manifestManager'], 'buildManifests');
-    const mockUploadManifest = vi.spyOn(uploader as any, 'uploadManifest');
-
-    uploader.onManifestUpdate();
-
-    expect(mockSetOriginalManifest).not.toHaveBeenCalled();
-    expect(mockBuildManifests).not.toHaveBeenCalled();
-    expect(mockUploadManifest).not.toHaveBeenCalled();
   });
 
   it('getTotalDurationFromFile parses all EXTINF durations', () => {


### PR DESCRIPTION
# 🔖 Title

Fixing Segment skips, cuts

## 📝 Description

There were occasions when segments were skipped during the stream, the duration of the stream was different in the manifest also end of stream was cut.

## 🔗 Related Issues

https://solar-punk.atlassian.net/browse/SPDV-297?atlOrigin=eyJpIjoiYzg4ZDIxNzI3YzY4NDc4ZTk0OTYxZmZhMTIwNzFjNjciLCJwIjoiaiJ9

https://solar-punk.atlassian.net/browse/SPDV-312?atlOrigin=eyJpIjoiNWY5ZjQzNGJlM2I2NDFiNmJiZGY4NmFlY2E3ZTI5ZjQiLCJwIjoiaiJ9


## ✨ Changes Made

So this was a little bit tricky. The server starts to become an async hell slowly so I'll consider redesigning the whole thing. For now, the fix is the following:

- set manifest upload queue concurrency to 1
 It was 10 which sometimes made false segment entries to the manifest, also it introduces some overhead if there was not an entry tick during a change.
 
- only read the manifest if it exists, also read it when the task actually happens (during upload)

- when the stream stopped
  The watcher could ignore segments and manifest changes
I made a streamDrain watcher which ensures that after stop every segment are processed and updated in the manifests.

## 🧪 How Has This Been Tested?

- [x] Manually tested
- [x] Added unit tests with Jest
